### PR TITLE
feat: add early flush handing drain event

### DIFF
--- a/docs/streams-api.md
+++ b/docs/streams-api.md
@@ -72,18 +72,6 @@ A method to write data to the stream, filter the chunk and push it to the buffer
   | void | This function does not return anything. |
 
 
-### _read (function)
-
-
-
-Push once false if at least one chunk has not matched.
-
-  #### Returns
-  | Type       | Description                             |
-  |------------|-----------------------------------------|
-  | void |  |
-
-
 ### _final (function)
 
 
@@ -106,24 +94,25 @@ and executing the final callback.
 
 
 
-Push once false if at least one chunk has not matched.
+Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
-### _read (function)
+### _flush (function)
 
+`private` 
 
-
-Push once false if at least one chunk has not matched.
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
 ## AnyMatchStream
@@ -165,18 +154,6 @@ A method to write data to the stream, filter the chunk and push it to the buffer
   | void | This function does not return anything. |
 
 
-### _read (function)
-
-
-
-Push once false if at least one chunk has matched.
-
-  #### Returns
-  | Type       | Description                             |
-  |------------|-----------------------------------------|
-  | void |  |
-
-
 ### _final (function)
 
 
@@ -199,24 +176,25 @@ and executing the final callback.
 
 
 
-Push once false if at least one chunk has matched.
+Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
-### _read (function)
+### _flush (function)
 
+`private` 
 
-
-Push once false if at least one chunk has matched.
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
 ## BufferStream
@@ -293,6 +271,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ## CountStream
 
 `extends SingleObjectDuplex` 
@@ -332,18 +322,6 @@ and executes the callback.
   | void |  |
 
 
-### _read (function)
-
-
-
-Reading is not supported since writer finishes first.
-
-  #### Returns
-  | Type       | Description                             |
-  |------------|-----------------------------------------|
-  | void |  |
-
-
 ### _final (function)
 
 
@@ -366,24 +344,25 @@ and executing the final callback.
 
 
 
-Reading is not supported since writer finishes first.
+Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
-### _read (function)
+### _flush (function)
 
+`private` 
 
-
-Reading is not supported since writer finishes first.
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
 ## DistinctStream
@@ -461,6 +440,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ## EmptyStream
 
 `extends SingleObjectDuplex` 
@@ -499,18 +490,6 @@ A method to write data to the stream, setting the hasChunks flag to true, and ex
   | void | This function does not return anything. |
 
 
-### _read (function)
-
-
-
-Push once false if at least one chunk has been received.
-
-  #### Returns
-  | Type       | Description                             |
-  |------------|-----------------------------------------|
-  | void |  |
-
-
 ### _final (function)
 
 
@@ -533,24 +512,25 @@ and executing the final callback.
 
 
 
-Push once false if at least one chunk has been received.
+Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
-### _read (function)
+### _flush (function)
 
+`private` 
 
-
-Push once false if at least one chunk has been received.
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
 ## FilterStream
@@ -627,6 +607,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ## FirstStream
 
 `extends DiscardingSingleObjectDuplex` 
@@ -688,6 +680,19 @@ and executing the final callback.
 
 
 Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
+### _flush (function)
+
+`private` 
+
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
@@ -761,6 +766,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | Name       | Description                             | Type                         |
   |------------|-----------------------------------------|------------------------------|
   | **size** | The size parameter for controlling the read operation. | number |
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
 
   #### Returns
   | Type       | Description                             |
@@ -876,6 +893,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ### _final (function)
 
 
@@ -931,18 +960,6 @@ A method to write data to the stream, setting the hasChunks flag to true, and ex
   | void | This function does not return anything. |
 
 
-### _read (function)
-
-
-
-Push once true if at least one chunk has been received.
-
-  #### Returns
-  | Type       | Description                             |
-  |------------|-----------------------------------------|
-  | void |  |
-
-
 ### _final (function)
 
 
@@ -965,24 +982,25 @@ and executing the final callback.
 
 
 
-Push once true if at least one chunk has been received.
+Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
-### _read (function)
+### _flush (function)
 
+`private` 
 
-
-Push once true if at least one chunk has been received.
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
 ## LastStream
@@ -1023,18 +1041,6 @@ A method to write data to the stream, save last chunk and discard the rest, and 
   | void | This function does not return anything. |
 
 
-### _read (function)
-
-
-
-Reading is not supported since writer finishes first.
-
-  #### Returns
-  | Type       | Description                             |
-  |------------|-----------------------------------------|
-  | void |  |
-
-
 ### _final (function)
 
 
@@ -1057,24 +1063,25 @@ and executing the final callback.
 
 
 
-Reading is not supported since writer finishes first.
+Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
-### _read (function)
+### _flush (function)
 
+`private` 
 
-
-Reading is not supported since writer finishes first.
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
   |------------|-----------------------------------------|
-  | void |  |
+  | void | This function does not return anything. |
 
 
 ## ParallelStream
@@ -1172,6 +1179,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | Name       | Description                             | Type                         |
   |------------|-----------------------------------------|------------------------------|
   | **size** | The size parameter for controlling the read operation. | number |
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
 
   #### Returns
   | Type       | Description                             |
@@ -1322,6 +1341,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ## DiscardingInternalBufferDuplex
 
 `abstract` `extends InternalBufferDuplex` 
@@ -1376,6 +1407,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ## DiscardingSingleObjectDuplex
 
 `abstract` `extends SingleObjectDuplex` 
@@ -1392,6 +1435,7 @@ Abstract class that allows you to emit discarded data in a single data stream ad
   | Name       | Description                             | Type                         |
   |------------|-----------------------------------------|------------------------------|
   | **options** |  | ObjectDuplexOptions |
+  | **canEarlyFlush** | A function that returns a boolean indicating whether the stream can early flush. | function |
 
 
 
@@ -1418,6 +1462,19 @@ and executing the final callback.
 
 
 Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
+### _flush (function)
+
+`private` 
+
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |
@@ -1494,6 +1551,18 @@ Pushes the ready chunks to the consumer stream since the buffer is empty or the 
   | void | This function does not return anything. |
 
 
+### _flush (function)
+
+`protected` 
+
+Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
 ## ObjectDuplex
 
 `abstract` `extends Duplex` 
@@ -1554,6 +1623,7 @@ Abstract class that allows you to emit a single data in a stream.
   | Name       | Description                             | Type                         |
   |------------|-----------------------------------------|------------------------------|
   | **options** |  | ObjectDuplexOptions |
+  | **canEarlyFlush** | A function that returns a boolean indicating whether the stream can early flush. | function |
 
 
 
@@ -1580,6 +1650,19 @@ and executing the final callback.
 
 
 Pushes the result chunk, if it exists and not pushed, to the consumer stream and marks it as pushed.
+
+  #### Returns
+  | Type       | Description                             |
+  |------------|-----------------------------------------|
+  | void | This function does not return anything. |
+
+
+### _flush (function)
+
+`private` 
+
+Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+This function is recursive and will keep flushing the buffer until it is empty.
 
   #### Returns
   | Type       | Description                             |

--- a/src/streams/classes/AllMatchStream.ts
+++ b/src/streams/classes/AllMatchStream.ts
@@ -45,7 +45,7 @@ export class AllMatchStream<T> extends DiscardingSingleObjectDuplex<T,boolean> {
      * @param [options.matcher] {Function} - The function that will be used to validate the chunk.
      */
     constructor(options: AllMatchStreamOptions<T>) {
-        super(options);
+        super(options, ()=>this.result === false);
         this._matcher = options.matcher;
     }
 
@@ -61,20 +61,11 @@ export class AllMatchStream<T> extends DiscardingSingleObjectDuplex<T,boolean> {
         const matcherResult = this._matcher(chunk);
         if(this.result === undefined || this.result){
             this.result = matcherResult;
+            this._flush();
         }
         if(!matcherResult){
             this.emit("discard", chunk);
         }
         callback();
-    }
-
-    /**
-     * Push once false if at least one chunk has not matched.
-     *
-     * @override
-     * @return {void}
-     */
-    _read(): void {
-        if(this.result === false) super._read();
     }
 }

--- a/src/streams/classes/AnyMatchStream.ts
+++ b/src/streams/classes/AnyMatchStream.ts
@@ -45,7 +45,7 @@ export class AnyMatchStream<T> extends DiscardingSingleObjectDuplex<T,boolean> {
      * @param [options.matcher] {Function} - The function that will be used to validate the chunk.
      */
     constructor(options: AnyMatchStreamOptions<T>) {
-        super(options);
+        super(options,()=>this.result === false);
         this._matcher = options.matcher;
     }
 
@@ -61,20 +61,11 @@ export class AnyMatchStream<T> extends DiscardingSingleObjectDuplex<T,boolean> {
         const matcherResult = this._matcher(chunk);
         if(this.result === undefined || this.result){
             this.result = !matcherResult;
+            this._flush();
         }
         if(matcherResult){
             this.emit("discard", chunk);
         }
         callback();
-    }
-
-    /**
-     * Push once false if at least one chunk has matched.
-     *
-     * @override
-     * @return {void}
-     */
-    _read(): void {
-        if(this.result === false && !this.pushedResult) super._read();
     }
 }

--- a/src/streams/classes/BufferStream.ts
+++ b/src/streams/classes/BufferStream.ts
@@ -38,6 +38,8 @@ export interface BufferStreamOptions extends ObjectDuplexOptions {
  */
 export class BufferStream<T> extends ObjectDuplex {
     protected buffer: T[] = [];
+    private isAwaitingDrain: boolean = false;
+    private finalCallback?: TransformCallback;
     private readonly batchSize: number;
 
     /**
@@ -60,6 +62,7 @@ export class BufferStream<T> extends ObjectDuplex {
      */
     _write(chunk: T, encoding: BufferEncoding, callback: TransformCallback): void {
         this.buffer.push(chunk);
+        this._flush();
         callback();
     }
 
@@ -71,27 +74,8 @@ export class BufferStream<T> extends ObjectDuplex {
      * @return {void} This function does not return anything.
      */
     _final(callback: TransformCallback): void {
-        /**
-         * Pushes the next batch of elements from the buffer to the stream, handling backpressure.
-         *
-         * @return {void} This function does not return anything.
-         */
-        const pushNext = () => {
-            if (this.buffer.length === 0) {
-                callback();
-                this.push(null);
-                return;
-            }
-    
-            const batch = this.buffer.splice(0, this.batchSize);
-            if (!this.push(batch)) {
-                this.once("drain", pushNext);
-            } else {
-                setImmediate(pushNext);
-            }
-        };
-    
-        pushNext();
+        this.finalCallback = callback;
+        this._flush();
     }
 
     /**
@@ -100,13 +84,33 @@ export class BufferStream<T> extends ObjectDuplex {
      * @param {number} size - The size parameter for controlling the read operation.
      * @return {void} This function does not return anything.
      */
-    _read(size: number): void {
-        while (this.buffer.length >= this.batchSize && size > 0) {
+    _read(): void {
+        this._flush();
+    }
+
+    /**
+     * Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+     * @protected
+     * @return {void} This function does not return anything.
+     */
+    protected _flush(): void {
+        if (this.isAwaitingDrain) return;
+
+        while (this.buffer.length >= this.batchSize || (this.finalCallback && this.buffer.length > 0)) {
             const batch = this.buffer.splice(0, this.batchSize);
-            if (!this.push(batch)) {
+            if(!this.push(batch)){
+                this.isAwaitingDrain = true;
+                this.once("drain", () => {
+                    this.isAwaitingDrain = false;
+                    this._flush();
+                });
                 return;
-            }
-            size--;
+            };
+        }
+
+        if(this.finalCallback){
+            this.push(null);
+            this.finalCallback();
         }
     }
 }

--- a/src/streams/classes/CountStream.ts
+++ b/src/streams/classes/CountStream.ts
@@ -33,7 +33,7 @@ export class CountStream<T> extends SingleObjectDuplex<number> {
      * @param {ObjectDuplexOptions} options - The options for the GroupBy.
      */
     constructor(options: ObjectDuplexOptions) {
-        super(options);
+        super(options,()=>false);
     }
 
     /**
@@ -50,15 +50,5 @@ export class CountStream<T> extends SingleObjectDuplex<number> {
             this.result++;
         }
         callback();
-    }
-
-    /**
-     * Reading is not supported since writer finishes first.
-     *
-     * @override
-     * @return {void}
-     */
-    _read(): void {
-        return;
     }
 }

--- a/src/streams/classes/DistinctStream.ts
+++ b/src/streams/classes/DistinctStream.ts
@@ -69,7 +69,8 @@ export class DistinctStream<TInput,TKey> extends DiscardingInternalBufferDuplex<
     _write(chunk: TInput, encoding: BufferEncoding, callback: TransformCallback): void {
         const key = this._keyExtractor(chunk);
         if(!this.keySet.has(key)){
-            this.buffer.push(chunk);
+            this.push(chunk);
+            this._flush();
             this.keySet.add(key);
         }else{
             this.emit("discard", chunk);

--- a/src/streams/classes/EmptyStream.ts
+++ b/src/streams/classes/EmptyStream.ts
@@ -30,7 +30,7 @@ export class EmptyStream<T> extends SingleObjectDuplex<boolean> {
      * @param {ObjectDuplexOptions} options - The options for the EmptyStream.
      */
     constructor(options: ObjectDuplexOptions) {
-        super(options);
+        super(options,()=>!this.result);
     }
 
     /**
@@ -43,16 +43,7 @@ export class EmptyStream<T> extends SingleObjectDuplex<boolean> {
      */
     _write(chunk: T, encoding: BufferEncoding, callback: TransformCallback): void {
         this.result = false;
+        this._flush();
         callback();
-    }
-
-    /**
-     * Push once false if at least one chunk has been received.
-     *
-     * @override
-     * @return {void}
-     */
-    _read(): void {
-        if(!this.result) super._read();
     }
 }

--- a/src/streams/classes/FilterStream.ts
+++ b/src/streams/classes/FilterStream.ts
@@ -65,6 +65,7 @@ export class FilterStream<T> extends DiscardingInternalBufferDuplex<T> {
     _write(chunk: T, encoding: BufferEncoding, callback: TransformCallback): void {
         if(this._filter(chunk)){
             this.buffer.push(chunk);
+            this._flush();
         }else{
             this.emit("discard", chunk);
         }

--- a/src/streams/classes/FirstStream.ts
+++ b/src/streams/classes/FirstStream.ts
@@ -38,7 +38,7 @@ export class FirstStream<T> extends DiscardingSingleObjectDuplex<T,T> {
      * @param {ObjectDuplexOptions} options - The options for the FirstStream.
      */
     constructor(options: ObjectDuplexOptions) {
-        super(options);
+        super(options,()=>true);
     }
 
     /**
@@ -52,6 +52,7 @@ export class FirstStream<T> extends DiscardingSingleObjectDuplex<T,T> {
     _write(chunk: T, encoding: BufferEncoding, callback: TransformCallback): void {
         if(this.result === undefined){
             this.result = chunk;
+            this._flush();
         }else{
             this.emit("discard", chunk);
         }

--- a/src/streams/classes/FlatStream.ts
+++ b/src/streams/classes/FlatStream.ts
@@ -46,6 +46,7 @@ export class FlatStream<T> extends InternalBufferDuplex<T> {
      */
     _write(chunk: Array<T>, encoding: BufferEncoding, callback: TransformCallback): void {
         this.buffer.push(...chunk);
+        this._flush();
         callback();
     }
 }

--- a/src/streams/classes/HasElementsStream.ts
+++ b/src/streams/classes/HasElementsStream.ts
@@ -31,7 +31,7 @@ export class HasElementsStream<T> extends SingleObjectDuplex<boolean> {
      * @param {ObjectDuplexOptions} options - The options for the HasElementsStream.
      */
     constructor(options: ObjectDuplexOptions) {
-        super(options);
+        super(options,()=>this.result);
     }
 
     /**
@@ -44,16 +44,7 @@ export class HasElementsStream<T> extends SingleObjectDuplex<boolean> {
      */
     _write(chunk: T, encoding: BufferEncoding, callback: TransformCallback): void {
         this.result = true;
+        this._flush();
         callback();
-    }
-
-    /**
-     * Push once true if at least one chunk has been received.
-     *
-     * @override
-     * @return {void}
-     */
-    _read(): void {
-        if(this.result) super._read();
     }
 }

--- a/src/streams/classes/LastStream.ts
+++ b/src/streams/classes/LastStream.ts
@@ -38,7 +38,7 @@ export class LastStream<T> extends DiscardingSingleObjectDuplex<T,T> {
      * @param {ObjectDuplexOptions} options - The options for the LastStream.
      */
     constructor(options: ObjectDuplexOptions) {
-        super(options);
+        super(options,()=>false);
     }
 
     /**
@@ -55,15 +55,5 @@ export class LastStream<T> extends DiscardingSingleObjectDuplex<T,T> {
         }
         this.result = chunk;
         callback();
-    }
-
-    /**
-     * Reading is not supported since writer finishes first.
-     *
-     * @override
-     * @return {void}
-     */
-    _read(): void {
-        return;
     }
 }

--- a/src/streams/classes/ParallelStream.ts
+++ b/src/streams/classes/ParallelStream.ts
@@ -106,6 +106,7 @@ export class ParallelStream<TInput, TOutput> extends InternalBufferDuplex<TOutpu
             const promise = this.transform(chunk)
                 .then((result: TOutput) => {
                     this.buffer.push(result);
+                    this._flush();
                 })
                 .catch((err: Error) => {
                     this.emit("error", err);

--- a/src/streams/classes/ReplayStream.ts
+++ b/src/streams/classes/ReplayStream.ts
@@ -57,8 +57,9 @@ export class ReplayStream<T> extends InternalBufferDuplex<T> {
      * @return {void} This function does not return anything.
      */
     _write(chunk: T, encoding: BufferEncoding, callback: TransformCallback): void {
-        this.buffer.push(chunk);
         this.memory.push(chunk);
+        this.buffer.push(chunk);
+        this._flush();
         callback();
     }
 

--- a/src/streams/classes/SingleStream.ts
+++ b/src/streams/classes/SingleStream.ts
@@ -52,6 +52,7 @@ export class SingleStream<T> extends InternalBufferDuplex<T> {
         if (this.isFirstChunk) {
             this.isFirstChunk = false;
             this.buffer.push(chunk);
+            this._flush();
         } else {
             const error = new SingleStreamError();
             this.emit("error", error);

--- a/src/streams/interfaces/classes/DiscardingSingleObjectDuplex.ts
+++ b/src/streams/interfaces/classes/DiscardingSingleObjectDuplex.ts
@@ -49,9 +49,10 @@ export abstract class DiscardingSingleObjectDuplex<TInput,TOutput> extends Singl
     /**
      * @constructor
      * @param options {ObjectDuplexOptions}
+     * @param {Function} canEarlyFlush - A function that returns a boolean indicating whether the stream can early flush.
      */
-    constructor(options:ObjectDuplexOptions) {
-        super(options);
+    constructor(options:ObjectDuplexOptions, canEarlyFlush:()=>boolean) {
+        super(options, canEarlyFlush);
     }
 
     addListener<U extends keyof DiscardingStreamEventHandlers<TInput>>(event: U, listener: DiscardingStreamEventHandlers<TInput>[U]): this {

--- a/src/streams/interfaces/classes/InternalBufferDuplex.ts
+++ b/src/streams/interfaces/classes/InternalBufferDuplex.ts
@@ -10,6 +10,8 @@ import { ObjectDuplex, ObjectDuplexOptions } from "./ObjectDuplex";
  */
 export abstract class InternalBufferDuplex<T> extends ObjectDuplex {
     protected buffer: T[] = [];
+    private isAwaitingDrain: boolean = false;
+    private finalCallback?: TransformCallback;
 
     /**
      * @constructor
@@ -32,22 +34,8 @@ export abstract class InternalBufferDuplex<T> extends ObjectDuplex {
          *
          * @return {void} This function does not return anything.
          */
-        const pushNext = () => {
-            if (this.buffer.length === 0) {
-                callback();
-                this.push(null);
-                return;
-            }
-    
-            const chunk = this.buffer.shift() as T;
-            if (!this.push(chunk)) {
-                this.once("drain", pushNext);
-            } else {
-                setImmediate(pushNext);
-            }
-        };
-    
-        pushNext();
+        this.finalCallback = callback;
+        this._flush();
     }
 
     /**
@@ -56,13 +44,33 @@ export abstract class InternalBufferDuplex<T> extends ObjectDuplex {
      * @param {number} size - The size parameter for controlling the read operation.
      * @return {void} This function does not return anything.
      */
-    _read(size: number): void {
-        while (this.buffer.length > 0 && size > 0) {
+    _read(): void {
+        this._flush();
+    }
+
+    /**
+     * Pushes the next batch of elements from the buffer to the stream, handling backpressure.
+     * @protected
+     * @return {void} This function does not return anything.
+     */
+    protected _flush(): void {
+        if (this.isAwaitingDrain) return;
+
+        while (this.buffer.length > 0) {
             const chunk = this.buffer.shift() as T;
             if(!this.push(chunk)){
+                this.isAwaitingDrain = true;
+                this.once("drain", () => {
+                    this.isAwaitingDrain = false;
+                    this._flush();
+                });
                 return;
             };
-            size--;
+        }
+
+        if(this.finalCallback){
+            this.push(null);
+            this.finalCallback();
         }
     }
 }

--- a/src/streams/interfaces/classes/SingleObjectDuplex.ts
+++ b/src/streams/interfaces/classes/SingleObjectDuplex.ts
@@ -11,13 +11,17 @@ import { ObjectDuplex, ObjectDuplexOptions } from "./ObjectDuplex";
 export abstract class SingleObjectDuplex<T> extends ObjectDuplex {
     protected result: T | undefined = undefined;
     protected pushedResult = false;
+    private readonly canEarlyFlush:()=>boolean;
+    private finalCallback?: TransformCallback;
 
     /**
      * @constructor
      * @param {ObjectDuplexOptions} options 
+     * @param {Function} canEarlyFlush - A function that returns a boolean indicating whether the stream can early flush.
      */
-    constructor(options: ObjectDuplexOptions) {
+    constructor(options: ObjectDuplexOptions, canEarlyFlush:()=>boolean) {
         super(options);
+        this.canEarlyFlush = canEarlyFlush;
     }
 
 
@@ -29,14 +33,8 @@ export abstract class SingleObjectDuplex<T> extends ObjectDuplex {
      * @return {void} This function does not return anything.
      */
     _final(callback: TransformCallback): void {
-        if (!this.pushedResult ) {
-            if(this.result !== undefined){
-                this.push(this.result);
-            }
-            this.pushedResult = true;
-            this.push(null);
-        }
-        callback();
+        this.finalCallback = callback;
+        this._flush();
     }
 
     /**
@@ -45,10 +43,32 @@ export abstract class SingleObjectDuplex<T> extends ObjectDuplex {
      * @return {void} This function does not return anything.
      */
     _read(): void {
-        if (!this.pushedResult && this.result !== undefined) {
-            this.push(this.result);
-            this.pushedResult = true;
-            this.push(null);
+        this._flush();
+    }
+
+    /**
+     * Flushes the buffer by pushing its content to the consumer stream. If the consumer stream is not ready to receive data, it waits for the drain event and flushes the buffer again when it is emitted.
+     * This function is recursive and will keep flushing the buffer until it is empty.
+     *
+     * @private
+     * @return {void} This function does not return anything.
+     */
+    protected _flush(): void {
+        if(!this.finalCallback){
+            if (!this.pushedResult && this.result !== undefined && this.canEarlyFlush()) {
+                this.push(this.result);
+                this.pushedResult = true;
+                this.push(null);
+            }
+        }else{
+            if (!this.pushedResult ) {
+                if(this.result !== undefined){
+                    this.push(this.result);
+                }
+                this.pushedResult = true;
+                this.push(null);
+            }
+            this.finalCallback();
         }
     }
 }

--- a/test/streams/interfaces/classes/DiscardingInternalBufferDuplex.test.ts
+++ b/test/streams/interfaces/classes/DiscardingInternalBufferDuplex.test.ts
@@ -1,7 +1,7 @@
 import { TransformCallback } from "stream";
 import { DiscardingInternalBufferDuplex } from "../../../../src/streams/index";
 
-describe("DiscardingStream", () => {
+describe("DiscardingInternalBufferDuplex", () => {
     class DiscardingStreamImplementation extends DiscardingInternalBufferDuplex<string> {
         constructor(){
             super({objectMode: true});

--- a/test/streams/interfaces/classes/DiscardingSingleObjectDuplex.test.ts
+++ b/test/streams/interfaces/classes/DiscardingSingleObjectDuplex.test.ts
@@ -1,18 +1,16 @@
 import { TransformCallback } from "stream";
 import { DiscardingSingleObjectDuplex } from "../../../../src/streams/index";
 
-describe("DiscardingStream", () => {
+describe("DiscardingSingleObjectDuplex", () => {
     class DiscardingStreamImplementation extends DiscardingSingleObjectDuplex<string, string> {
         constructor(){
-            super({objectMode: true});
+            super({objectMode: true},()=>false);
         }
 
         _write(chunk: string, encoding: BufferEncoding, callback: TransformCallback): void {
             this.emit("discard", chunk);
             callback();
         }
-
-        _read(): void {return}
     }
     let stream: DiscardingStreamImplementation;
     let chunks: Array<string>;


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [X] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [X] Documentation

### Description
**Provide a brief description of the change.**
Add early flush feature in order to push data as soon as possible. This feature handle backpressure wainting drain to continu flusing in bufered streams

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests. If removed, please explain why in additional notes.**
- [ ] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [X] Documentation updated

### Additional Notes
**Provide any additional information or context related to this pull request.**

---

## Pull Request Checklist
- [X] Code adheres to the project's coding style guide.
- [X] All tests are passing.
- [X] The pull request description is complete.
- [X] Documentation is updated if needed.
